### PR TITLE
Remove 'profiles' from docker config

### DIFF
--- a/docker-compose/kafka.yaml
+++ b/docker-compose/kafka.yaml
@@ -62,6 +62,7 @@ services:
     entrypoint: ./kowl --config.filepath=/etc/kowl/config.yaml
     depends_on:
       - kafka
+      - schema-registry
 
   # Kafka Prometheus exporter https://github.com/cloudhut/kminion
   kafka-minion:


### PR DESCRIPTION
* 'profiles' option doesn't work with docker 20.10.21.

* Upon docker-compose up, the following error is thrown:
> no such service: kafka-setup