### PR TITLE
Added mem limits

### DIFF
--- a/docker-compose/es.yaml
+++ b/docker-compose/es.yaml
@@ -1,7 +1,6 @@
-version: '2.1'
+version: "2.1"
 
 services:
-
   es:
     image: elasticsearch:7.17.8
     hostname: es
@@ -13,6 +12,9 @@ services:
       - "xpack.security.enabled=false"
       - "xpack.license.self_generated.type=basic"
       - ELASTIC_PASSWORD=d6MR9LN8kwpqlZClVuP3WYxfZiuOEOEN
+    mem_limit: 2048m
+    cpus: 1
+    #cpu_percent: 10
     ports:
       - 9200:9200
     volumes:
@@ -34,12 +36,12 @@ services:
     #profiles:
     #  - donotstart
 
-  
   kibana:
     image: docker.elastic.co/kibana/kibana:7.17.8
     hostname: kibana
+    mem_limit: 1024m
     ports:
-     - 5601:5601
+      - 5601:5601
     environment:
       ELASTICSEARCH_HOSTS: '["http://es:9200"]'
     depends_on:

--- a/docker-compose/kafka.yaml
+++ b/docker-compose/kafka.yaml
@@ -1,7 +1,6 @@
-version: '2.1'
+version: "2.1"
 
 services:
-
   zoo:
     image: confluentinc/cp-zookeeper:7.2.1
     hostname: zoo
@@ -9,11 +8,12 @@ services:
       - "2181:2181"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
-   
+    mem_limit: 512m
 
   kafka:
     image: confluentinc/cp-kafka:7.2.1
     hostname: kafka
+    mem_limit: 1024m
     ports:
       - "9092:9092"
     environment:
@@ -44,7 +44,7 @@ services:
       - ../config/kafkaconfig.sh:/etc/config/kafkaconfig.sh
     command: "bash /etc/config/kafkaconfig.sh"
     depends_on:
-      kafka: 
+      kafka:
         condition: service_healthy
     environment:
       # The following settings are listed here only to satisfy the image's requirements.
@@ -56,12 +56,13 @@ services:
     image: docker.redpanda.com/vectorized/console:v2.1.1
     entrypoint: /bin/sh
     command: -c "/app/console"
+    mem_limit: 512m
     environment:
       CONFIG_FILEPATH: /tmp/config.yml
     volumes:
       - ../config/redpanda.yaml:/tmp/config.yml
     ports:
-      - 8080:8080
+      - "9898:8080"
     depends_on:
       kafka:
         condition: service_healthy
@@ -84,6 +85,7 @@ services:
       - donotstart
 
   schema-registry:
+    mem_limit: 256m
     image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
@@ -94,7 +96,7 @@ services:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'kafka:19092'
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "kafka:19092"
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
     healthcheck:
       test: nc -z localhost 8081 || exit -1


### PR DESCRIPTION
I have had issues where ES and kafka hogged all memory, and when i wanted to start up additional containers, such as jobs, there was no memory left