### PR TITLE
Feature/adding timescale db

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 COMPOSE_PROJECT_NAME=cheetah-infrastructure
 COMPOSE_PATH_SEPARATOR=:
-COMPOSE_FILE=docker-compose/es.yaml:docker-compose/kafka.yaml
+COMPOSE_FILE=docker-compose/es.yaml:docker-compose/kafka.yaml:docker-compose/timescaledb.yaml

--- a/config/pgadmin/pgpass
+++ b/config/pgadmin/pgpass
@@ -1,0 +1,1 @@
+timescaledb:5432:timescaledb:timescaledb:cheetah

--- a/config/pgadmin/servers.json
+++ b/config/pgadmin/servers.json
@@ -1,0 +1,14 @@
+{
+    "Servers": {
+      "1": {
+        "Name": "timescaledb",
+        "Group": "Servers",
+        "Host": "timescaledb",
+        "Port": 5432,
+        "MaintenanceDB": "postgres",
+        "Username": "timescaledb",
+        "PassFile": "/pgpass",
+        "SSLMode": "prefer"
+      }
+    }
+  }

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -7,7 +7,7 @@ services:
       - 5432:5432
     environment:
       POSTGRES_USER: timescaledb
-      POSTGRES_PASSWORD: cheetah
+      POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - timescaledb:/var/lib/postgresql/data
   
@@ -20,6 +20,8 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: pgadmin4@pgadmin.org
       PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
     volumes:
       - pgadmin-data:/var/lib/pgadmin
       - ../config/pgadmin/servers.json:/pgadmin4/servers.json

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -1,19 +1,33 @@
-
-
 services:
-
   timescaledb:
-      image: timescale/timescaledb:latest-pg12
-      restart: always
-      ports:
-        - 5432:5432
-      environment:
-        POSTGRES_USER: timescaledb
-        POSTGRES_PASSWORD: cheetah
-      volumes:
-        - /data/timescaledb:/var/lib/postgresql/data
+    image: timescale/timescaledb:latest-pg12
+    restart: unless-stopped
+    mem_limit: 1024m
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: timescaledb
+      POSTGRES_PASSWORD: cheetah
+    volumes:
+      - timescaledb:/var/lib/postgresql/data
+  
+  pgadmin:
+    image: dpage/pgadmin4
+    restart: unless-stopped
+    container_name: pgadmin4_container
+    ports:
+      - "5050:80"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: pgadmin4@pgadmin.org
+      PGADMIN_DEFAULT_PASSWORD: admin
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
 
 networks:
   default:
     name: "cheetah-infrastructure"
     external: true
+
+volumes:
+  timescaledb:
+  pgadmin-data:

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -14,7 +14,6 @@ services:
   pgadmin:
     image: dpage/pgadmin4
     restart: unless-stopped
-    container_name: pgadmin4_container
     ports:
       - "5050:80"
     environment:

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -1,0 +1,19 @@
+
+
+services:
+
+  timescaledb:
+      image: timescale/timescaledb:latest-pg12
+      restart: always
+      ports:
+        - 5432:5432
+      environment:
+        POSTGRES_USER: timescaledb
+        POSTGRES_PASSWORD: cheetah
+      volumes:
+        - /data/timescaledb:/var/lib/postgresql/data
+
+networks:
+  default:
+    name: "cheetah-infrastructure"
+    external: true

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -22,6 +22,8 @@ services:
       PGADMIN_DEFAULT_PASSWORD: admin
     volumes:
       - pgadmin-data:/var/lib/pgadmin
+      - ../config/pgadmin/servers.json:/pgadmin4/servers.json
+      - ../config/pgadmin/pgpass:/pgpass
 
 networks:
   default:


### PR DESCRIPTION
Adds timescaledb and pgAdmin.

pgAdmin is exposed on http://localhost:5050 and is pre-provisioned with a connection to timescaledb