### PR TITLE
Feature/timescale with extensions

### DIFF
--- a/config/pgadmin/servers.json
+++ b/config/pgadmin/servers.json
@@ -4,7 +4,7 @@
             "Name": "cheetah",
             "Group": "Servers",
             "Port": 5432,
-            "Username": "timescaledb",
+            "Username": "postgres",
             "Host": "timescaledb",
             "SSLMode": "prefer",
             "MaintenanceDB": "postgres",

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -8,7 +8,8 @@ services:
       - 5432:5432
     environment:
       POSTGRES_DB: mydatabase
-      POSTGRES_USER: timescaledb
+      POSTGRES_USER: postgres
+      POSTGRESQL_PASSWORD: admin
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - timescaledb:/var/lib/postgresql/data
@@ -17,7 +18,7 @@ services:
 
   pgadmin:
     container_name: pgadmin
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:8.5
     restart: unless-stopped
     ports:
       - "5050:80"

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -1,7 +1,7 @@
 services:
   timescaledb:
     container_name: timescaledb
-    image: timescale/timescaledb:latest-pg12
+    image: timescale/timescaledb:2.14.2-pg16-bitnami
     restart: unless-stopped
     mem_limit: 1024m
     ports:

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -8,7 +8,6 @@ services:
       - 5432:5432
     environment:
       POSTGRES_DB: mydatabase
-      POSTGRES_USER: postgres
       POSTGRESQL_PASSWORD: admin
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,30 @@ And query OpenSearch like this:
 curl -k -s -H "Authorization: Bearer $ACCESS_TOKEN" $OPENSEARCH_URL/_cat/indices
 ```
 
+## Timescale
+
+The Timescale setup consists of different services:
+* **TimescaleDB** PostgreSQL with the timescale extension
+* **PgAdmin** GUI for managing TimescaleDB
+
+### Running TimescaleDB and its associated services
+
+Run:
+
+```bash
+docker compose --profile=timescale up -d
+```
+
+When all of the services are running, you can go to:
+
+- <http://localhost:5432/> TimescaleDB
+- <http://localhost:5050> to see the PgAdmin UI
+
+### Authentication
+
+By default a single user is setup:
+* **Username**: `postgres`, **Password**: `admin`
+
 ## List of all profiles in docker compose
 
 **List of profiles:**


### PR DESCRIPTION
Changed the timescale image to `2.14.2-pg16-bitnami` due to a feature request. `2.14.2-pg16-bitnami` has more builtin extensions compared to `latest-pg12`

Also changed authentication to be **Username**: `postgres`, **Password**: `admin`