### PR TITLE
Feature/remove bitnami from timescaledb

### DIFF
--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -8,7 +8,7 @@ services:
       - 5432:5432
     environment:
       POSTGRES_DB: mydatabase
-      POSTGRESQL_PASSWORD: admin
+      POSTGRES_PASSWORD: admin
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - timescaledb:/var/lib/postgresql/data

--- a/docker-compose/timescaledb.yaml
+++ b/docker-compose/timescaledb.yaml
@@ -1,7 +1,7 @@
 services:
   timescaledb:
     container_name: timescaledb
-    image: timescale/timescaledb:2.17.2-pg16-bitnami
+    image: timescale/timescaledb:2.17.2-pg16
     restart: unless-stopped
     mem_limit: 1024m
     ports:


### PR DESCRIPTION
Adjusting environment variables to match new dependency on base image. Now just uses upstream timescaledb image. 