### PR TITLE
Removes trivy temporarily

### DIFF
--- a/docker-compose/kafka.yaml
+++ b/docker-compose/kafka.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   kafka:
-    image: ${CHEETAH_DOCKER_REGISTRY-}cheetah-infrastructure-utils-kafka:strimzi-0.48.0-kafka-4.1.0-trifork-1.9.0
+    image: ${CHEETAH_DOCKER_REGISTRY-}cheetah-infrastructure-utils-kafka:strimzi-0.45.0-kafka-3.9.0-trifork-1.8.0
 
     container_name: kafka
     hostname: kafka
@@ -42,7 +42,7 @@ services:
       - full
 
   kafka-setup:
-    image: quay.io/strimzi/kafka:0.48.0-kafka-4.1.0
+    image: quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
     container_name: kafka-setup
     volumes:
       - ./config/kafkaconfig.sh:/etc/config/kafkaconfig.sh
@@ -70,7 +70,7 @@ services:
   redpanda:
     mem_limit: 128m
     container_name: redpanda
-    image: redpandadata/console:v3.2.2
+    image: redpandadata/console:v2.8.10
     entrypoint: /bin/sh
     command: -c "/app/console"
     environment:
@@ -101,7 +101,7 @@ services:
   # Kafka Prometheus exporter https://github.com/cloudhut/kminion
   kafka-minion:
     mem_limit: 128m
-    image: redpandadata/kminion:v2.2.17
+    image: redpandadata/kminion:v2.2.14
     hostname: kafka-minion
     container_name: kafka-minion
     depends_on:


### PR DESCRIPTION
Critical Vulnerability in Trivys ecosystem

[GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)

https://www.docker.com/blog/trivy-supply-chain-compromise-what-docker-hub-users-should-know/